### PR TITLE
Feature/add version bump script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,3 +68,25 @@ This project follows a generalised semantic versioning where major versions are 
 - **Version bumps are at maintainer discretion** - not every PR requires a version change.
 - When versions are updated, `pyproject.toml`, `src/panhumanpy/__init__.py`, and `README.md` must be kept in sync.
 - Use versioning script for version bumps executed in a consistent fashion.
+
+
+### Using the Version Bump Script
+
+For consistent version updates, use the provided script:
+
+```bash
+# Check current version
+python scripts/bump_version.py current
+
+# Check version consistency across files
+python scripts/bump_version.py check
+
+# Bug fixes (patch)
+python scripts/bump_version.py patch
+
+# New features (minor)
+python scripts/bump_version.py minor
+
+# New models or breaking changes (major)
+python scripts/bump_version.py major Cassiopeia
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "panhumanpy"
 version = "0.1.0"
-description = "..."
+description = "A Python package for automated cell type annotation in scRNA-seq using Azimuth Neural Network."
 readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.9"

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -120,11 +120,11 @@ def update_file(file_path, old_version_str, new_version_str, new_name=None):
     elif file_path == README_FILE:
         #old_version_str is being used to build the regex string for robustness
         pattern = re.compile(rf'(\*\*Current version: )({re.escape(old_version_str)}) \(([^)]+)\)\*\*')
-        content = pattern.sub(rf'\1{new_version_str} ({new_name})**', content)
+        content = pattern.sub(f'**Current version: {new_version_str} ({new_name})**', content)
     
     elif file_path == CONTRIBUTING_FILE:
-        pattern = re.compile(rf'(- )({re.escape(old_version_str)}\s*\()([^)]+)\)')
-        content = pattern.sub(rf'\1{new_version_str} ({new_name})`', content)
+        pattern = re.compile(rf'- {re.escape(old_version_str)} \([^)]+\)')
+        content = pattern.sub(f'- {new_version_str} ({new_name})', content)
         
     file_path.write_text(content)
 

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -6,30 +6,42 @@ Usage: python scripts/bump_version.py [major|minor|patch] [constellation_name]
 Examples:
     python scripts/bump_version.py patch                    # Bug fix
     python scripts/bump_version.py minor                    # New feature
-    python scripts/bump_version.py major Cassiopeia         # New model, breaking change
+    python scripts/bump_version.py major Cassiopeia         # New model, breaking changes to API
 """
 
 import re
 import sys
 from pathlib import Path
 
+# File paths for version info
+INIT_FILE = Path("src/panhumanpy/__init__.py")
+PYPROJECT_FILE = Path("pyproject.toml")
+README_FILE = Path("README.md")
+CONTRIBUTING_FILE = Path("CONTRIBUTING.md")
+
+# Regex patterns for finding version info
+VERSION_PATTERNS = {
+    "init": re.compile(r"__version__ = ['\"](\d+)\.(\d+)\.(\d+)['\"]"),
+    "name": re.compile(r"__version_name__ = ['\"]([^'\"]+)['\"]"),
+    "pyproject": re.compile(r"version = ['\"](\d+\.\d+\.\d+)['\"]"),
+    "readme": re.compile(r"\*\*Current version: ([\d.]+) \(([^)]+)\)\*\*"),
+    "contributing": re.compile(r"- ([\d.]+)\s*\(([^)]+)\)"), 
+}
+
 def get_current_version():
     """Get current version from __init__.py"""
-    init_file = Path("src/panhumanpy/__init__.py")
-    if not init_file.exists():
+    if not INIT_FILE.exists():
         print("❌ Error: Could not find src/panhumanpy/__init__.py")
         return None, None
     
-    content = init_file.read_text()
+    content = INIT_FILE.read_text()
     
-    # Extract version
-    version_match = re.search(r"__version__ = ['\"](\d+)\.(\d+)\.(\d+)['\"]", content)
+    version_match = VERSION_PATTERNS["init"].search(content)
     if not version_match:
         print("❌ Error: Could not find version in __init__.py")
         return None, None
     
-    # Extract constellation name
-    name_match = re.search(r"__version_name__ = ['\"]([^'\"]+)['\"]", content)
+    name_match = VERSION_PATTERNS["name"].search(content)
     if not name_match:
         print("❌ Error: Could not find version name in __init__.py")
         return None, None
@@ -39,172 +51,175 @@ def get_current_version():
     
     return (major, minor, patch), constellation
 
-def update_version_in_file(file_path, old_version, new_version, old_name=None, new_name=None):
-    """Update version in a file"""
-    content = Path(file_path).read_text()
-    
-    # Create version strings
-    old_version_str = f"{old_version[0]}.{old_version[1]}.{old_version[2]}"
-    new_version_str = f"{new_version[0]}.{new_version[1]}.{new_version[2]}"
-    
-    # Sanity check: verify current version matches expected old version
-    current_version_match = re.search(rf'version = ["\']([^"\']+)["\']', content)
-    if current_version_match:
-        current_version = current_version_match.group(1)
-        if current_version != old_version_str:
-            print(f"⚠️  Warning: Expected version {old_version_str} but found {current_version} in {file_path}")
-    
-    current_version_match = re.search(rf'__version__ = ["\']([^"\']+)["\']', content)
-    if current_version_match:
-        current_version = current_version_match.group(1)
-        if current_version != old_version_str:
-            print(f"⚠️  Warning: Expected __version__ {old_version_str} but found {current_version} in {file_path}")
-    
-    # Sanity check: verify current constellation name matches expected old name
-    if old_name:
-        current_name_match = re.search(rf'__version_name__ = ["\']([^"\']+)["\']', content)
-        if current_name_match:
-            current_name = current_name_match.group(1)
-            if current_name != old_name:
-                print(f"⚠️  Warning: Expected version name {old_name} but found {current_name} in {file_path}")
-    
-    # Update version number
-    content = re.sub(
-        rf'version = ["\'].*?["\']',
-        f'version = "{new_version_str}"',
-        content
-    )
-    
-    content = re.sub(
-        rf'__version__ = ["\'].*?["\']',
-        f'__version__ = "{new_version_str}"',
-        content
-    )
-    
-    # Update constellation name if provided
-    if old_name and new_name:
-        content = re.sub(
-            rf'__version_name__ = ["\'].*?["\']',
-            f'__version_name__ = "{new_name}"',
-            content
-        )
-    
-    Path(file_path).write_text(content)
+def check_file_consistency(file_path, version_str, constellation_name=None):
+    """Check that version info in a single file is consistent."""
+    if not file_path.exists():
+        print(f"⚠️  Warning: {file_path} not found, skipping consistency check.")
+        return True
 
-def update_contributing_version(old_version, new_version, old_name, new_name):
-    """Update version in CONTRIBUTING.md"""
-    contributing_path = Path("CONTRIBUTING.md")
-    if not contributing_path.exists():
-        print("⚠️  Warning: CONTRIBUTING.md not found, skipping")
+    content = file_path.read_text()
+    
+    if file_path == PYPROJECT_FILE:
+        match = VERSION_PATTERNS["pyproject"].search(content)
+        if match and match.group(1) == version_str:
+            return True
+    elif file_path == README_FILE:
+        match = VERSION_PATTERNS["readme"].search(content)
+        if match and match.group(1) == version_str and match.group(2) == constellation_name:
+            return True
+    elif file_path == CONTRIBUTING_FILE:
+        match = VERSION_PATTERNS["contributing"].search(content)
+        if match and match.group(1) == version_str and match.group(2) == constellation_name:
+            return True
+    
+    print(f"❌ Version mismatch in {file_path}")
+    print(f"   Expected version: {version_str}")
+    if constellation_name:
+        print(f"   Expected name: {constellation_name}")
+    print(f"   Found: {match.group(0) if match else 'None'}")
+    return False
+
+def check_all_consistency(current_version, current_constellation):
+    """Check version consistency across all files"""
+    current_version_str = f"{current_version[0]}.{current_version[1]}.{current_version[2]}"
+    
+    print("🔍 Checking version consistency across files...")
+    
+    files_to_check = [
+        (PYPROJECT_FILE, current_version_str, None),
+        (README_FILE, current_version_str, current_constellation),
+        (CONTRIBUTING_FILE, current_version_str, current_constellation)
+    ]
+    
+    for file, version_str, name in files_to_check:
+        if not check_file_consistency(file, version_str, name):
+            print("\n❌ Version inconsistency detected!")
+            return False
+            
+    print("✅ All files have consistent version information")
+    return True
+
+def update_file(file_path, old_version_str, new_version_str, new_name=None):
+    """Update version and name in a single file based on its type."""
+    if not file_path.exists():
+        print(f"⚠️  Warning: {file_path} not found, skipping update.")
         return
+        
+    content = file_path.read_text()
     
-    content = contributing_path.read_text()
+    if file_path == INIT_FILE:
+        # Update version number
+        content = VERSION_PATTERNS["init"].sub(f'__version__ = "{new_version_str}"', content)
+        # Update version name
+        if new_name:
+            content = VERSION_PATTERNS["name"].sub(f'__version_name__ = "{new_name}"', content)
     
-    old_version_str = f"{old_version[0]}.{old_version[1]}.{old_version[2]}"
-    new_version_str = f"{new_version[0]}.{new_version[1]}.{new_version[2]}"
+    elif file_path == PYPROJECT_FILE:
+        content = VERSION_PATTERNS["pyproject"].sub(f'version = "{new_version_str}"', content)
+
+    elif file_path == README_FILE:
+        #old_version_str is being used to build the regex string for robustness
+        pattern = re.compile(rf'(\*\*Current version: )({re.escape(old_version_str)}) \(([^)]+)\)\*\*')
+        content = pattern.sub(rf'\1{new_version_str} ({new_name})**', content)
     
-    # Update the "Current Version:" section
-    old_line = f"- {old_version_str} ({old_name})"
-    new_line = f"- {new_version_str} ({new_name})"
-    
-    content = content.replace(old_line, new_line)
-    
-    contributing_path.write_text(content)
+    elif file_path == CONTRIBUTING_FILE:
+        pattern = re.compile(rf'(- )({re.escape(old_version_str)}\s*\()([^)]+)\)')
+        content = pattern.sub(rf'\1{new_version_str} ({new_name})`', content)
+        
+    file_path.write_text(content)
 
 def validate_constellation_name(constellation):
     """Validate constellation name format"""
     if not constellation:
         return False
-    
-    # Check if it's a valid constellation name (basic validation)
-    if not constellation.isalpha() or not constellation[0].isupper():
-        print("❌ Error: Constellation name should be capitalized and contain only letters")
+    if not constellation.isalpha() or not constellation[0].isupper() or constellation[1:].isupper():
+        print("❌ Error: First letter of constellation name must be capitalized and contain only letters")
         return False
-    
     return True
 
 def bump_version(bump_type, constellation=None):
     """Main version bumping logic"""
-    # Get current version
     current_version, current_constellation = get_current_version()
     if not current_version:
-        return False
+        return 1
+    
+    if not check_all_consistency(current_version, current_constellation):
+        return 1
     
     major, minor, patch = current_version
-    
     print(f"Current version: {major}.{minor}.{patch} ({current_constellation})")
     
-    # Calculate new version
+    new_constellation = current_constellation
+    
     if bump_type == "major":
         new_version = (major + 1, 0, 0)
         if not constellation:
-            print("❌ Error: Major version requires constellation name")
+            print("❌ Error: Major version requires a new constellation name.")
             print("Example: python scripts/bump_version.py major Cassiopeia")
-            return False
+            return 1
         if not validate_constellation_name(constellation):
-            return False
+            return 1
         new_constellation = constellation
     elif bump_type == "minor":
         new_version = (major, minor + 1, 0)
-        new_constellation = current_constellation
     elif bump_type == "patch":
         new_version = (major, minor, patch + 1)
-        new_constellation = current_constellation
     else:
         print("❌ Error: Invalid bump type. Use 'major', 'minor', or 'patch'")
-        return False
+        return 1
     
     new_version_str = f"{new_version[0]}.{new_version[1]}.{new_version[2]}"
-    
     print(f"New version: {new_version_str} ({new_constellation})")
     
-    # Confirm with user
     confirm = input("Proceed with version bump? (y/N): ")
     if confirm.lower() != 'y':
         print("❌ Version bump cancelled")
-        return False
+        return 1
     
-    # Update files
     try:
-        # Update pyproject.toml
-        update_version_in_file("pyproject.toml", current_version, new_version)
+        update_file(PYPROJECT_FILE, f"{major}.{minor}.{patch}", new_version_str)
         print("✅ Updated pyproject.toml")
         
-        # Update __init__.py
-        update_version_in_file(
-            "src/panhumanpy/__init__.py", 
-            current_version, 
-            new_version,
-            current_constellation,
-            new_constellation
+        update_file(
+            INIT_FILE, 
+            f"{major}.{minor}.{patch}", 
+            new_version_str,
+            new_name=new_constellation
         )
         print("✅ Updated src/panhumanpy/__init__.py")
         
-        # Update README.md
-        update_readme_version(current_version, new_version, current_constellation, new_constellation)
+        update_file(
+            README_FILE, 
+            f"{major}.{minor}.{patch}", 
+            new_version_str, 
+            new_name=new_constellation
+        )
         print("✅ Updated README.md")
-        
-        # Update CONTRIBUTING.md
-        update_contributing_version(current_version, new_version, current_constellation, new_constellation)
+
+        update_file(
+            CONTRIBUTING_FILE, 
+            f"{major}.{minor}.{patch}", 
+            new_version_str, 
+            new_name=new_constellation
+        )
         print("✅ Updated CONTRIBUTING.md")
-        
+
         print(f"\n🎉 Version successfully bumped to {new_version_str} ({new_constellation})")
         print("\nNext steps:")
         print("1. Review the changes: git diff")
         print("2. Commit the changes: git add . && git commit -m 'Bump version to {}'".format(new_version_str))
-        print("3. Tag the release: git tag v{}-{}".format(new_version_str, new_constellation.lower()))
-        print("3. Push tags: git push origin --tags")
+        print("3. Tag the release: git tag v{}-{}".format(new_version_str, new_constellation.lower())) 
+        print("4. Push changes and tags: git push --follow-tags") 
         
-        return True
-        
+        return 0
     except Exception as e:
         print(f"❌ Error updating files: {e}")
-        return False
+        return 1
 
 def show_help():
     """Show usage help"""
     print(__doc__)
-    print("\nNote: Constellation names are chosen on-the-fly for major versions.")
+    print("\nNote: Constellation names are chosen on-the-fly for major versions")
 
 def main():
     if len(sys.argv) < 2:
@@ -223,6 +238,12 @@ def main():
             print(f"Current version: {version[0]}.{version[1]}.{version[2]} ({constellation})")
         return 0
     
+    if command == "check":
+        version, constellation = get_current_version()
+        if version:
+            check_all_consistency(version, constellation)
+        return 0
+    
     if command not in ["major", "minor", "patch"]:
         print(f"❌ Error: Invalid command '{command}'")
         show_help()
@@ -230,8 +251,7 @@ def main():
     
     constellation = sys.argv[2] if len(sys.argv) > 2 else None
     
-    success = bump_version(command, constellation)
-    return 0 if success else 1
+    return bump_version(command, constellation)
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""
+Version bumping script for panhumanpy following constellation protocol.
+Usage: python scripts/bump_version.py [major|minor|patch] [constellation_name]
+
+Examples:
+    python scripts/bump_version.py patch                    # Bug fix
+    python scripts/bump_version.py minor                    # New feature
+    python scripts/bump_version.py major Cassiopeia         # New model, breaking change
+"""
+
+import re
+import sys
+from pathlib import Path
+
+def get_current_version():
+    """Get current version from __init__.py"""
+    init_file = Path("src/panhumanpy/__init__.py")
+    if not init_file.exists():
+        print("❌ Error: Could not find src/panhumanpy/__init__.py")
+        return None, None
+    
+    content = init_file.read_text()
+    
+    # Extract version
+    version_match = re.search(r"__version__ = ['\"](\d+)\.(\d+)\.(\d+)['\"]", content)
+    if not version_match:
+        print("❌ Error: Could not find version in __init__.py")
+        return None, None
+    
+    # Extract constellation name
+    name_match = re.search(r"__version_name__ = ['\"]([^'\"]+)['\"]", content)
+    if not name_match:
+        print("❌ Error: Could not find version name in __init__.py")
+        return None, None
+    
+    major, minor, patch = map(int, version_match.groups())
+    constellation = name_match.group(1)
+    
+    return (major, minor, patch), constellation
+
+def update_version_in_file(file_path, old_version, new_version, old_name=None, new_name=None):
+    """Update version in a file"""
+    content = Path(file_path).read_text()
+    
+    # Create version strings
+    old_version_str = f"{old_version[0]}.{old_version[1]}.{old_version[2]}"
+    new_version_str = f"{new_version[0]}.{new_version[1]}.{new_version[2]}"
+    
+    # Sanity check: verify current version matches expected old version
+    current_version_match = re.search(rf'version = ["\']([^"\']+)["\']', content)
+    if current_version_match:
+        current_version = current_version_match.group(1)
+        if current_version != old_version_str:
+            print(f"⚠️  Warning: Expected version {old_version_str} but found {current_version} in {file_path}")
+    
+    current_version_match = re.search(rf'__version__ = ["\']([^"\']+)["\']', content)
+    if current_version_match:
+        current_version = current_version_match.group(1)
+        if current_version != old_version_str:
+            print(f"⚠️  Warning: Expected __version__ {old_version_str} but found {current_version} in {file_path}")
+    
+    # Sanity check: verify current constellation name matches expected old name
+    if old_name:
+        current_name_match = re.search(rf'__version_name__ = ["\']([^"\']+)["\']', content)
+        if current_name_match:
+            current_name = current_name_match.group(1)
+            if current_name != old_name:
+                print(f"⚠️  Warning: Expected version name {old_name} but found {current_name} in {file_path}")
+    
+    # Update version number
+    content = re.sub(
+        rf'version = ["\'].*?["\']',
+        f'version = "{new_version_str}"',
+        content
+    )
+    
+    content = re.sub(
+        rf'__version__ = ["\'].*?["\']',
+        f'__version__ = "{new_version_str}"',
+        content
+    )
+    
+    # Update constellation name if provided
+    if old_name and new_name:
+        content = re.sub(
+            rf'__version_name__ = ["\'].*?["\']',
+            f'__version_name__ = "{new_name}"',
+            content
+        )
+    
+    Path(file_path).write_text(content)
+
+def update_contributing_version(old_version, new_version, old_name, new_name):
+    """Update version in CONTRIBUTING.md"""
+    contributing_path = Path("CONTRIBUTING.md")
+    if not contributing_path.exists():
+        print("⚠️  Warning: CONTRIBUTING.md not found, skipping")
+        return
+    
+    content = contributing_path.read_text()
+    
+    old_version_str = f"{old_version[0]}.{old_version[1]}.{old_version[2]}"
+    new_version_str = f"{new_version[0]}.{new_version[1]}.{new_version[2]}"
+    
+    # Update the "Current Version:" section
+    old_line = f"- {old_version_str} ({old_name})"
+    new_line = f"- {new_version_str} ({new_name})"
+    
+    content = content.replace(old_line, new_line)
+    
+    contributing_path.write_text(content)
+
+def validate_constellation_name(constellation):
+    """Validate constellation name format"""
+    if not constellation:
+        return False
+    
+    # Check if it's a valid constellation name (basic validation)
+    if not constellation.isalpha() or not constellation[0].isupper():
+        print("❌ Error: Constellation name should be capitalized and contain only letters")
+        return False
+    
+    return True
+
+def bump_version(bump_type, constellation=None):
+    """Main version bumping logic"""
+    # Get current version
+    current_version, current_constellation = get_current_version()
+    if not current_version:
+        return False
+    
+    major, minor, patch = current_version
+    
+    print(f"Current version: {major}.{minor}.{patch} ({current_constellation})")
+    
+    # Calculate new version
+    if bump_type == "major":
+        new_version = (major + 1, 0, 0)
+        if not constellation:
+            print("❌ Error: Major version requires constellation name")
+            print("Example: python scripts/bump_version.py major Cassiopeia")
+            return False
+        if not validate_constellation_name(constellation):
+            return False
+        new_constellation = constellation
+    elif bump_type == "minor":
+        new_version = (major, minor + 1, 0)
+        new_constellation = current_constellation
+    elif bump_type == "patch":
+        new_version = (major, minor, patch + 1)
+        new_constellation = current_constellation
+    else:
+        print("❌ Error: Invalid bump type. Use 'major', 'minor', or 'patch'")
+        return False
+    
+    new_version_str = f"{new_version[0]}.{new_version[1]}.{new_version[2]}"
+    
+    print(f"New version: {new_version_str} ({new_constellation})")
+    
+    # Confirm with user
+    confirm = input("Proceed with version bump? (y/N): ")
+    if confirm.lower() != 'y':
+        print("❌ Version bump cancelled")
+        return False
+    
+    # Update files
+    try:
+        # Update pyproject.toml
+        update_version_in_file("pyproject.toml", current_version, new_version)
+        print("✅ Updated pyproject.toml")
+        
+        # Update __init__.py
+        update_version_in_file(
+            "src/panhumanpy/__init__.py", 
+            current_version, 
+            new_version,
+            current_constellation,
+            new_constellation
+        )
+        print("✅ Updated src/panhumanpy/__init__.py")
+        
+        # Update README.md
+        update_readme_version(current_version, new_version, current_constellation, new_constellation)
+        print("✅ Updated README.md")
+        
+        # Update CONTRIBUTING.md
+        update_contributing_version(current_version, new_version, current_constellation, new_constellation)
+        print("✅ Updated CONTRIBUTING.md")
+        
+        print(f"\n🎉 Version successfully bumped to {new_version_str} ({new_constellation})")
+        print("\nNext steps:")
+        print("1. Review the changes: git diff")
+        print("2. Commit the changes: git add . && git commit -m 'Bump version to {}'".format(new_version_str))
+        print("3. Tag the release: git tag v{}-{}".format(new_version_str, new_constellation.lower()))
+        print("3. Push tags: git push origin --tags")
+        
+        return True
+        
+    except Exception as e:
+        print(f"❌ Error updating files: {e}")
+        return False
+
+def show_help():
+    """Show usage help"""
+    print(__doc__)
+    print("\nNote: Constellation names are chosen on-the-fly for major versions.")
+
+def main():
+    if len(sys.argv) < 2:
+        show_help()
+        return 1
+    
+    command = sys.argv[1]
+    
+    if command in ["help", "-h", "--help"]:
+        show_help()
+        return 0
+    
+    if command == "current":
+        version, constellation = get_current_version()
+        if version:
+            print(f"Current version: {version[0]}.{version[1]}.{version[2]} ({constellation})")
+        return 0
+    
+    if command not in ["major", "minor", "patch"]:
+        print(f"❌ Error: Invalid command '{command}'")
+        show_help()
+        return 1
+    
+    constellation = sys.argv[2] if len(sys.argv) > 2 else None
+    
+    success = bump_version(command, constellation)
+    return 0 if success else 1
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_bump_version.py
+++ b/tests/test_bump_version.py
@@ -1,0 +1,224 @@
+import tempfile
+import shutil
+from pathlib import Path
+import pytest
+import sys
+import os
+import unittest.mock
+
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+import bump_version
+
+class TestBumpVersion:
+    
+    def setup_method(self):
+        """Create a temporary directory with test files"""
+        self.test_dir = Path(tempfile.mkdtemp())
+        os.chdir(self.test_dir)
+        
+        # Create directory structure
+        (self.test_dir / "src" / "panhumanpy").mkdir(parents=True)
+        
+        # Create test files with initial versions
+        self.create_test_files()
+        
+    def teardown_method(self):
+        """Clean up temporary directory"""
+        os.chdir(Path.home())  # Change out of temp dir
+        shutil.rmtree(self.test_dir)
+    
+    def create_test_files(self):
+        """Create test files with version 1.0.0 (TestConstellation)"""
+        
+        # src/panhumanpy/__init__.py
+        init_content = '''"""Test package"""
+__version__ = "1.0.0"
+__version_name__ = "TestConstellation"
+__version_full__ = f"{__version__} ({__version_name__})"
+'''
+        (self.test_dir / "src" / "panhumanpy" / "__init__.py").write_text(init_content)
+        
+        # pyproject.toml
+        pyproject_content = '''[project]
+name = "test-package"
+version = "1.0.0"
+description = "Test package"
+'''
+        (self.test_dir / "pyproject.toml").write_text(pyproject_content)
+        
+        # README.md
+        readme_content = '''# Test Package
+
+**Current version: 1.0.0 (TestConstellation)**
+
+Description here.
+'''
+        (self.test_dir / "README.md").write_text(readme_content)
+        
+        # CONTRIBUTING.md
+        contributing_content = '''## Developer's Guide
+
+### Version Types:
+- MAJOR: New model
+
+#### Current Version:
+- 1.0.0 (TestConstellation)
+
+More content here.
+'''
+        (self.test_dir / "CONTRIBUTING.md").write_text(contributing_content)
+
+    def test_get_current_version(self):
+        """Test getting current version from __init__.py"""
+        version, constellation = bump_version.get_current_version()
+        assert version == (1, 0, 0)
+        assert constellation == "TestConstellation"
+
+    def test_check_consistency_when_consistent(self):
+        """Test consistency check passes when all files match"""
+        version, constellation = bump_version.get_current_version()
+        assert bump_version.check_all_consistency(version, constellation) == True
+
+    def test_check_consistency_when_inconsistent(self):
+        """Test consistency check fails when files don't match"""
+        # Modify pyproject.toml to have wrong version
+        pyproject_path = self.test_dir / "pyproject.toml"
+        content = pyproject_path.read_text()
+        content = content.replace('version = "1.0.0"', 'version = "2.0.0"')
+        pyproject_path.write_text(content)
+        
+        version, constellation = bump_version.get_current_version()
+        assert bump_version.check_all_consistency(version, constellation) == False
+
+    def test_init_missing_version(self):
+        init_path = self.test_dir / "src" / "panhumanpy" / "__init__.py"
+        init_path.write_text('__version_name__ = "TestConstellation"') # Missing __version__
+        version, constellation = bump_version.get_current_version()
+        assert version is None
+        assert constellation is None
+
+    def test_init_missing_name(self):
+        init_path = self.test_dir / "src" / "panhumanpy" / "__init__.py"
+        init_path.write_text('__version__ = "1.0.0"') # Missing __version_name__
+        version, constellation = bump_version.get_current_version()
+        assert version is None
+        assert constellation is None
+
+    def test_patch_version_bump(self):
+        """Test patch version bump (1.0.0 -> 1.0.1)"""
+        with unittest.mock.patch('builtins.input', return_value='y'):
+            result = bump_version.bump_version("patch")
+            assert result == 0
+        
+        # Check version was updated correctly
+        version, constellation = bump_version.get_current_version()
+        assert version == (1, 0, 1)
+        assert constellation == "TestConstellation"
+        
+        # Check ALL files are consistent
+        assert bump_version.check_all_consistency(version, constellation) == True
+        
+        # Explicitly verify each file was updated
+        pyproject_content = (self.test_dir / "pyproject.toml").read_text()
+        assert "1.0.1" in pyproject_content
+        
+        readme_content = (self.test_dir / "README.md").read_text()
+        assert "1.0.1 (TestConstellation)" in readme_content
+        
+        contributing_content = (self.test_dir / "CONTRIBUTING.md").read_text()
+        assert "1.0.1 (TestConstellation)" in contributing_content
+
+    def test_minor_version_bump(self):
+        """Test minor version bump (1.0.0 -> 1.1.0)"""
+        with unittest.mock.patch('builtins.input', return_value='y'):
+            result = bump_version.bump_version("minor")
+            assert result == 0
+        
+        # Check version was updated correctly
+        version, constellation = bump_version.get_current_version()
+        assert version == (1, 1, 0)
+        assert constellation == "TestConstellation" 
+        
+        # Check ALL files are consistent
+        assert bump_version.check_all_consistency(version, constellation) == True
+        
+        # Explicitly verify each file was updated
+        pyproject_content = (self.test_dir / "pyproject.toml").read_text()
+        assert "1.1.0" in pyproject_content
+        
+        readme_content = (self.test_dir / "README.md").read_text()
+        assert "1.1.0 (TestConstellation)" in readme_content
+        
+        contributing_content = (self.test_dir / "CONTRIBUTING.md").read_text()
+        assert "1.1.0 (TestConstellation)" in contributing_content
+
+    def test_major_version_bump(self):
+        """Test major version bump (1.0.0 -> 2.0.0) with new constellation"""
+        with unittest.mock.patch('builtins.input', return_value='y'):
+            result = bump_version.bump_version("major", "NewConstellation")
+            assert result == 0
+        
+        # Check version was updated correctly
+        version, constellation = bump_version.get_current_version()
+        assert version == (2, 0, 0)
+        assert constellation == "NewConstellation" 
+        
+        # Check ALL files are consistent
+        assert bump_version.check_all_consistency(version, constellation) == True
+        
+        # Explicitly verify each file was updated
+        pyproject_content = (self.test_dir / "pyproject.toml").read_text()
+        assert "2.0.0" in pyproject_content
+        
+        readme_content = (self.test_dir / "README.md").read_text()
+        assert "2.0.0 (NewConstellation)" in readme_content
+        
+        contributing_content = (self.test_dir / "CONTRIBUTING.md").read_text()
+        assert "2.0.0 (NewConstellation)" in contributing_content
+
+    def test_major_version_without_constellation_fails(self):
+        """Test that major version bump fails without constellation name"""
+        result = bump_version.bump_version("major")
+        assert result == 1 
+
+    def test_invalid_constellation_name_fails(self):
+        """Test that invalid constellation names are rejected"""
+        result = bump_version.bump_version("major", "invalidname")  # lowercase
+        assert result == 1
+        
+        result = bump_version.bump_version("major", "ALLCAPS")  # all caps
+        assert result == 1
+        
+        result = bump_version.bump_version("major", "Invalid123")  # numbers
+        assert result == 1
+
+    def test_user_cancellation(self):
+        """Test that user can cancel version bump"""
+        
+        with unittest.mock.patch('builtins.input', return_value='n'):
+            result = bump_version.bump_version("patch")
+            assert result == 1
+        
+        # Version should not have changed
+        version, constellation = bump_version.get_current_version()
+        assert version == (1, 0, 0)
+        assert constellation == "TestConstellation"
+
+    def test_missing_init_file(self):
+        """Test behavior when __init__.py is missing"""
+        (self.test_dir / "src" / "panhumanpy" / "__init__.py").unlink()
+        
+        version, constellation = bump_version.get_current_version()
+        assert version is None
+        assert constellation is None
+
+    def test_validate_constellation_name(self):
+        """Test constellation name validation"""
+        assert bump_version.validate_constellation_name("Andromeda") == True
+        assert bump_version.validate_constellation_name("Cassiopeia") == True
+        assert bump_version.validate_constellation_name("andromeda") == False  # lowercase
+        assert bump_version.validate_constellation_name("ANDROMEDA") == False  # all caps
+        assert bump_version.validate_constellation_name("Andromeda123") == False  # numbers
+        assert bump_version.validate_constellation_name("") == False  # empty
+        assert bump_version.validate_constellation_name(None) == False  # None


### PR DESCRIPTION
## Description
Checklist of guidelines to go through when making a PR.

## Type of Change
- [ ] Bug fix (patch version)
- [x] New or updated feature (minor version)  
- [ ] New model (major version + new constellation for version name)
- [ ] Documentation update
- [ ] Internal refactoring

**Does this PR introduce a breaking change to the *public API* of existing features/models?**
- [ ] Yes (If yes, this *will* require a Major version bump. Explain in "Additional Notes")
- [x] No

## Pre-Merge Checklist
**Please check each item before requesting review:**

### Code Quality
- [x] Tests pass locally: `python -m pytest tests/`
- [x] New functionality has tests written
- [x] No debugging code left behind (print statements, breakpoints)
- [x] Package installs cleanly: `pip install -e .`

### Documentation
- [x] README.md updated for user-facing changes and model version updates if necessary
- [x] Docstrings added for new functions
- [ ] Tutorial notebook updated if needed

### Model Changes (if applicable)
- [ ] New models tested with sample data
- [ ] Model files added to appropriate `_tools/` subdirectory
- [ ] Backward compatibility maintained (old models still work)

### Git Hygiene
- [x] Branch is up to date with main
- [x] No `__pycache__` files committed
- [x] Commit messages are descriptive
- [x] No merge conflicts

## Version Impact (Maintainer Decision)
- [ ] No version change needed
- [ ] Should trigger version bump:
  - [ ] Patch (bug fix)
  - [x] Minor (new or updated feature)  
  - [ ] Major (breaking change to existing API, **or a new model** which is a "soft" breaking change) - change constellation for version name

## Testing
Added new tests in tests module.

## Additional Notes
Semantic versioning typically reserves major version updates for breaking changes in the API. We'll generalise this slightly to also include
updates where we are adding a new model to the package even though we aim to ensure backwards compatibility with previous models. This is
because by default the API will point to the latest model and thus this represents a "soft" breaking change. 
