### PR TITLE
Patch/refinement v0 broad

### DIFF
--- a/src/panhumanpy/ANNotate.py
+++ b/src/panhumanpy/ANNotate.py
@@ -587,34 +587,31 @@ class AzimuthNN_base(AutoloadInferenceTools):
             "Interpreting label predictions for consistent granularity "
             f"at {refine_level} level.\n")
 
-        if refine_level in ['medium', 'fine']:
-
-            labels_pred = self._inference_outputs_unprocessed[
-                'hierarchical_label_preds'
-            ]
-            labels_prob = self._inference_outputs_unprocessed[
-                'probability_of_preds'
-            ]
-            softmax_probs = self._inference_outputs_unprocessed[
-                'softmax_vals_all'
-            ]
-
-            refine_class = PostprocessingAzimuthLabels(
-                labels_pred,
-                labels_prob,
-                self.max_depth,
-                self.num_cells,
-                softmax_probs,
-                self.inference_encoders,
-                refine_level,
-                self._model_version
-            )
-
-            results = refine_class.refine_labels()
         
-        else:
-            results = self.processed_outputs['level_zero_labels']
+        labels_pred = self._inference_outputs_unprocessed[
+            'hierarchical_label_preds'
+        ]
+        labels_prob = self._inference_outputs_unprocessed[
+            'probability_of_preds'
+        ]
+        softmax_probs = self._inference_outputs_unprocessed[
+            'softmax_vals_all'
+        ]
 
+        refine_class = PostprocessingAzimuthLabels(
+            labels_pred,
+            labels_prob,
+            self.max_depth,
+            self.num_cells,
+            softmax_probs,
+            self.inference_encoders,
+            refine_level,
+            self._model_version
+        )
+
+        results = refine_class.refine_labels()
+        
+        
         (
             self._azimuth_refined_labels[f'azimuth_{refine_level}']
          ) = results

--- a/src/panhumanpy/_tools/v0/postprocessing/panhuman_annotate_broad.csv
+++ b/src/panhumanpy/_tools/v0/postprocessing/panhuman_annotate_broad.csv
@@ -1,0 +1,392 @@
+Orig_Label,Annotate_broad
+Adipocyte,Adipocyte
+Doublet like cell|Ductal/EC doublet like cell,Doublet like cell
+Doublet like cell|Fibroblast/Granulosa doublet like cell,Doublet like cell
+Embryonic cell|Mesodermal cell|Cycling mesodermal cell,Embryonic cell
+Embryonic cell|Mesodermal cell|ZEB2+ mesoderm,Embryonic cell
+Embryonic cell|Trophoblast|Cytotrophoblast|PSG5+ syncytiotrophoblast,Embryonic cell
+Embryonic cell|Trophoblast|Cytotrophoblast|SLC13A4+ syncytiotrophoblast,Embryonic cell
+Embryonic cell|Trophoblast|Cytotrophoblast|Villous cytotrophoblast|Cycling villous cytotrophoblast,Embryonic cell
+Embryonic cell|Trophoblast|Extravillous trophoblast|Cycling extravillous trophoblast,Embryonic cell
+Embryonic cell|Trophoblast|INF-activated trophoblast,Embryonic cell
+Embryonic cell|Trophoblast|Syncytiotrophoblast|SLC13A4+ Syncytiotrophoblast,Embryonic cell
+Endothelial cell|ACTA2+ EC,Endothelial cell
+Endothelial cell|Arterial EC|ACTA2+ arterial EC,Endothelial cell
+Endothelial cell|Arterial EC|Fetal MHC- arterial EC|Fetal MHC- Collagen+ arterial EC,Endothelial cell
+Endothelial cell|Arterial EC|SRGN+ arterial EC,Endothelial cell
+Endothelial cell|BGN+ EC,Endothelial cell
+Endothelial cell|Capillary EC|ACTA2+ capillary EC,Endothelial cell
+Endothelial cell|Capillary EC|Fetal MHC- capillary EC|Fetal MHC- Collagen+ capillary EC,Endothelial cell
+Endothelial cell|Capillary EC|Glomerular capillary EC,Endothelial cell
+Endothelial cell|Cycling EC,Endothelial cell
+Endothelial cell|Endocardial cell,Endothelial cell
+Endothelial cell|Lymphatic EC,Endothelial cell
+Endothelial cell|Venous EC|Fetal MHC- venous EC|Fetal MHC- Collagen+ venous EC,Endothelial cell
+Endothelial cell|Endothelial‑mesenchymal transition EC,Endothelial cell
+Epithelial cell|Cycling epithelial cell,Epithelial cell
+Epithelial cell|Endocrine cell,Epithelial cell
+Epithelial cell|Epithelial cell of adrenal gland|Capsular cell,Epithelial cell
+Epithelial cell|Epithelial cell of adrenal gland|Chromaffin cell,Epithelial cell
+Epithelial cell|Epithelial cell of adrenal gland|Steroidogenic cell,Epithelial cell
+Epithelial cell|Epithelial cell of adrenal gland|Sympathoadrenal cell,Epithelial cell
+Epithelial cell|Epithelial cell of adrenal gland|Sympathoblast,Epithelial cell
+Epithelial cell|Epithelial cell of bladder|Basal cell of bladder|DKK1+MMP1+ basal cell of bladder,Epithelial cell
+Epithelial cell|Epithelial cell of bladder|Basal cell of bladder|FOS+ basal cell of bladder,Epithelial cell
+Epithelial cell|Epithelial cell of bladder|Basal cell of bladder|MMP7+ basal cell of bladder,Epithelial cell
+Epithelial cell|Epithelial cell of breast|Lactocyte|Cycling lactocyte,Epithelial cell
+Epithelial cell|Epithelial cell of breast|Lactocyte|Metallothionein- lactocyte,Epithelial cell
+Epithelial cell|Epithelial cell of breast|Lactocyte|Metallothionein+ lactocyte,Epithelial cell
+Epithelial cell|Epithelial cell of breast|Mammary basal cell|CCSER1 mammary basal cell,Epithelial cell
+Epithelial cell|Epithelial cell of breast|Mammary basal cell|CXCL14 mammary basal cell,Epithelial cell
+Epithelial cell|Epithelial cell of breast|Mammary basal cell|KRT6B mammary basal cell,Epithelial cell
+Epithelial cell|Epithelial cell of breast|Mammary luminal cell|KRT17 mammary luminal cell,Epithelial cell
+Epithelial cell|Epithelial cell of breast|Mammary luminal cell|PIP mammary luminal cell,Epithelial cell
+Epithelial cell|Epithelial cell of breast|Mammary luminal cell|Secretoglobin mammary luminal cell,Epithelial cell
+Epithelial cell|Epithelial cell of breast|Mammary luminal cell|TNBC specific luminal cell,Epithelial cell
+Epithelial cell|Epithelial cell of breast|Mammary luminal progenitor|Cycling mammary luminal progenitor,Epithelial cell
+Epithelial cell|Epithelial cell of breast|Mammary luminal progenitor|SAA2 mammary luminal progenitor,Epithelial cell
+Epithelial cell|Epithelial cell of breast|Mammary luminal progenitor|SCGB3A1 mammary luminal progenitor,Epithelial cell
+Epithelial cell|Epithelial cell of breast|Mammary luminal progenitor|Secretoglobin mammary luminal progenitor,Epithelial cell
+Epithelial cell|Epithelial cell of breast|Mammary luminal progenitor|SFN mammary luminal progenitor,Epithelial cell
+Epithelial cell|Epithelial cell of breast|Mammary luminal progenitor|TNBC specific cycling luminal progenitor,Epithelial cell
+Epithelial cell|Epithelial cell of breast|Mammary luminal progenitor|TNBC specific luminal progenitor,Epithelial cell
+Epithelial cell|Epithelial cell of eye|Ciliary body cell,Epithelial cell
+Epithelial cell|Epithelial cell of eye|Corneal epithelial cell,Epithelial cell
+Epithelial cell|Epithelial cell of eye|Epithelial cell of conjunctiva,Epithelial cell
+Epithelial cell|Epithelial cell of eye|Retinal pigment epithelial cell,Epithelial cell
+Epithelial cell|Epithelial cell of eye|Uveal melanocyte,Epithelial cell
+Epithelial cell|Epithelial cell of eye|Eye melanocyte,Epithelial cell
+Epithelial cell|Epithelial cell of gingiva|Basal cell of gingiva|ECM1 basal cell,Epithelial cell
+Epithelial cell|Epithelial cell of gingiva|Basal cell of gingiva|KRT14 basal cell|Cycling KRT14 basal cell,Epithelial cell
+Epithelial cell|Epithelial cell of gingiva|Basal cell of gingiva|KRT14/ECM1 basal cell,Epithelial cell
+Epithelial cell|Epithelial cell of gingiva|Melanocyte,Epithelial cell
+Epithelial cell|Epithelial cell of gingiva|Merkel cell,Epithelial cell
+Epithelial cell|Epithelial cell of intestine|Colonocyte,Epithelial cell
+Epithelial cell|Epithelial cell of intestine|Enterocyte|BEST4 enterocyte,Epithelial cell
+Epithelial cell|Epithelial cell of intestine|Enteroendocrine cell,Epithelial cell
+Epithelial cell|Epithelial cell of intestine|Goblet cell|Cycling goblet cell,Epithelial cell
+Epithelial cell|Epithelial cell of intestine|Intestinal stem cell,Epithelial cell
+Epithelial cell|Epithelial cell of intestine|Microfold cell,Epithelial cell
+Epithelial cell|Epithelial cell of intestine|Paneth cell,Epithelial cell
+Epithelial cell|Epithelial cell of intestine|Transit-amplifying cell|G2/M phase transit-amplifying cell,Epithelial cell
+Epithelial cell|Epithelial cell of intestine|Transit-amplifying cell|S phase transit-amplifying cell,Epithelial cell
+Epithelial cell|Epithelial cell of intestine|Tuft cell,Epithelial cell
+Epithelial cell|Epithelial cell of intestine|Squamous epithelial cell,Epithelial cell
+Epithelial cell|Epithelial cell of kidney|Renal intercalated cell|Podocyte,Epithelial cell
+Epithelial cell|Epithelial cell of kidney|Renal intercalated cell|Type A intercalated cell,Epithelial cell
+Epithelial cell|Epithelial cell of kidney|Renal intercalated cell|Type B intercalated cell,Epithelial cell
+Epithelial cell|Epithelial cell of liver|cholangiocyte|CXCL6+ cholangiocyte,Epithelial cell
+Epithelial cell|Epithelial cell of liver|cholangiocyte|SPINK1+SGMS2+ cholangiocyte,Epithelial cell
+Epithelial cell|Epithelial cell of liver|cholangiocyte|TFF+ cholangiocyte,Epithelial cell
+Epithelial cell|Epithelial cell of liver|Hepatocyte|AFP+ fetal hepatocyte,Epithelial cell
+Epithelial cell|Epithelial cell of lung|Aerocyte,Epithelial cell
+Epithelial cell|Epithelial cell of lung|Airway basal cell,Epithelial cell
+Epithelial cell|Epithelial cell of lung|Alveolar epithelial cell|AT1,Epithelial cell
+Epithelial cell|Epithelial cell of lung|Alveolar epithelial cell|AT2|Cycling AT2,Epithelial cell
+Epithelial cell|Epithelial cell of lung|Club cell,Epithelial cell
+Epithelial cell|Epithelial cell of lung|Multiciliated cell|CDC20B+ Multiciliated cell,Epithelial cell
+Epithelial cell|Epithelial cell of lung|Neuroendocrine cell,Epithelial cell
+Epithelial cell|Epithelial cell of ovary|AFP+ epithelial cell,Epithelial cell
+Epithelial cell|Epithelial cell of ovary|CLDN3+ epithelial cell,Epithelial cell
+Epithelial cell|Epithelial cell of ovary|GABRP+ epithelial cell,Epithelial cell
+Epithelial cell|Epithelial cell of ovary|Granulosa cell|MT2A+ granulosa cell,Epithelial cell
+Epithelial cell|Epithelial cell of ovary|Granulosa cell|OSR1+ granulosa cell,Epithelial cell
+Epithelial cell|Epithelial cell of ovary|Granulosa cell|PAX8+ granulosa cell,Epithelial cell
+Epithelial cell|Epithelial cell of ovary|Granulosa cell|Steroidogenesis granulosa cell,Epithelial cell
+Epithelial cell|Epithelial cell of ovary|Granulosa cell|TAC1+ granulosa cell,Epithelial cell
+Epithelial cell|Epithelial cell of ovary|Ovarian cancer related epithelial cell|Ovarian cancer enriched cycling epithelial cell,Epithelial cell
+Epithelial cell|Epithelial cell of ovary|Ovarian cancer related epithelial cell|Ovarian cancer enriched S100A9+MUC16+ epithelial cell,Epithelial cell
+Epithelial cell|Epithelial cell of ovary|Ovarian cancer related epithelial cell|Ovarian cancer specific EMT cell,Epithelial cell
+Epithelial cell|Epithelial cell of ovary|Ovarian cancer related epithelial cell|Ovarian cancer specific LGR5+MUC16+ epithelial cell,Epithelial cell
+Epithelial cell|Epithelial cell of pancreas|Acinar cell,Epithelial cell
+Epithelial cell|Epithelial cell of pancreas|Alpha cell,Epithelial cell
+Epithelial cell|Epithelial cell of pancreas|Beta cell,Epithelial cell
+Epithelial cell|Epithelial cell of pancreas|Epsilon cell,Epithelial cell
+Epithelial cell|Epithelial cell of pancreas|Pancreatic ductal cell|CCL2+ pancreatic ductal cell,Epithelial cell
+Epithelial cell|Epithelial cell of pancreas|Pancreatic ductal cell|HSP+ pancreatic ductal cell,Epithelial cell
+Epithelial cell|Epithelial cell of pancreas|Pancreatic ductal cell|MT2A+ ductal cell,Epithelial cell
+Epithelial cell|Epithelial cell of pancreas|Pancreatic ductal cell|TFF1+ ductal cell,Epithelial cell
+Epithelial cell|Epithelial cell of pancreas|Pancreatic ductal cell|TUBA1A+ ductal cell,Epithelial cell
+Epithelial cell|Epithelial cell of pancreas|PP cell,Epithelial cell
+Epithelial cell|Epithelial cell of pancreas|Metallothionein+ epithelial cell,Epithelial cell
+Epithelial cell|Epithelial cell of skin|Keratinocyte|Basal keratinocyte,Epithelial cell
+Epithelial cell|Epithelial cell of skin|Keratinocyte|Cycling keratinocyte,Epithelial cell
+Epithelial cell|Epithelial cell of skin|Keratinocyte|Granular keratinocyte,Epithelial cell
+Epithelial cell|Epithelial cell of skin|Keratinocyte|Secretory cell,Epithelial cell
+Epithelial cell|Epithelial cell of skin|Keratinocyte|Spinous keratinocyte,Epithelial cell
+Epithelial cell|Epithelial cell of skin|Merkel cell carcinoma enriched epithelial cell,Epithelial cell
+Epithelial cell|Epithelial cell of stomach|Chief cell,Epithelial cell
+Epithelial cell|Epithelial cell of stomach|Delta cell,Epithelial cell
+Epithelial cell|Epithelial cell of stomach|Enterochromaffin cell,Epithelial cell
+Epithelial cell|Epithelial cell of stomach|SCGB2A1+ endocrine cell,Epithelial cell
+Epithelial cell|Epithelial cell of stomach|Surface mucous cell|CXCL2/3+ surface mucous cell,Epithelial cell
+Epithelial cell|Epithelial cell of stomach|Surface mucous cell|Cycling surface mucous cell|G2/M phase surface mucous cell,Epithelial cell
+Epithelial cell|Epithelial cell of stomach|Surface mucous cell|Cycling surface mucous cell|S phase surface mucous cell,Epithelial cell
+Epithelial cell|Epithelial cell of stomach|Surface mucous cell|GKN1/2+ surface mucous cell,Epithelial cell
+Epithelial cell|Epithelial cell of testis|Leydig cell|Cycling Leydig cell,Epithelial cell
+Epithelial cell|Epithelial cell of testis|Leydig cell|Fetal Leydig cell,Epithelial cell
+Epithelial cell|Epithelial cell of testis|Leydig cell|IL1RAPL1+ Leyding cell,Epithelial cell
+Epithelial cell|Epithelial cell of testis|Leydig cell|INSL3+ Leydig cell,Epithelial cell
+Epithelial cell|Epithelial cell of testis|Leydig cell|Leydig cell progenitor,Epithelial cell
+Epithelial cell|Epithelial cell of testis|Peritubular myoid cell|Peritubular myoid cell progenitor,Epithelial cell
+Epithelial cell|Epithelial cell of testis|Sertoli and Interstitial cell common progenitor,Epithelial cell
+Epithelial cell|Epithelial cell of testis|Sertoli cell|Cycling Sertoli cell,Epithelial cell
+Epithelial cell|Epithelial cell of testis|Sertoli cell|ROBO2+ fetal Sertoli cell,Epithelial cell
+Epithelial cell|Epithelial cell of testis|Supporting-like PAX8+ cell,Epithelial cell
+Epithelial cell|Epithelial cell of testis|Luminal cell,Epithelial cell
+Epithelial cell|Epithelial cell of thymus|Cortical thymic epithelial cell,Epithelial cell
+Epithelial cell|Epithelial cell of thymus|Cycling thymic epithelial cell,Epithelial cell
+Epithelial cell|Epithelial cell of thymus|Medullary thymic epithelial cell|Corneocyte-like mTEC,Epithelial cell
+Epithelial cell|Epithelial cell of thymus|Medullary thymic epithelial cell|Immature medullary thymic epithelial cell,Epithelial cell
+Epithelial cell|Epithelial cell of thymus|Thymic ciliated cell,Epithelial cell
+Epithelial cell|Epithelial cell of thymus|Thymic myoid cell,Epithelial cell
+Epithelial cell|Epithelial cell of tonsil|Tonsillar crypt epithelial cell,Epithelial cell
+Epithelial cell|Mesothelial cell|CRABP1+ mesothelial cell,Epithelial cell
+Epithelial cell|Mesothelial cell|Cycling mesothelial cell,Epithelial cell
+Epithelial cell|Mesothelial cell|GATA4+ mesothelial cell,Epithelial cell
+Epithelial cell|PDAC related epithelial cell|Cycling PDAC specific ductal cell,Epithelial cell
+Epithelial cell|PDAC related epithelial cell|PDAC specific ductal cell,Epithelial cell
+Fibroblast|BNC2+ZFPM2+ fibroblast,Fibroblast
+Fibroblast|CFD+MGP+ fibroblast|ADAM12+ fibroblast,Fibroblast
+Fibroblast|CFD+MGP+ fibroblast|CDH19+LAMA2+ fibroblast,Fibroblast
+Fibroblast|CFD+MGP+ fibroblast|MFAP5+IGFBP6+ fibroblast|Cycling MFAP5+IGFBP6+ fibroblast|G2/M phase MFAP5+IGFBP6+ fibroblast,Fibroblast
+Fibroblast|CFD+MGP+ fibroblast|MFAP5+IGFBP6+ fibroblast|Cycling MFAP5+IGFBP6+ fibroblast|S phase MFAP5+IGFBP6+ fibroblast,Fibroblast
+Fibroblast|CFD+MGP+ fibroblast|C7+ fibroblast,Fibroblast
+Fibroblast|CFD+MGP+ fibroblast|CXCL14+ fibroblast|CXCL14+C7+ fibroblast,Fibroblast
+Fibroblast|CFD+MGP+ fibroblast|CXCL14+ fibroblast|Cycling CXCL14+ fibroblast,Fibroblast
+Fibroblast|CFD+MGP+ fibroblast|CXCL14+ fibroblast|PTGDS+CXCL14+ fibroblast,Fibroblast
+Fibroblast|CFD+MGP+ fibroblast|CXCL14+ fibroblast|CXCL14+POSTN+ fibroblast,Fibroblast
+Fibroblast|CFD+MGP+ fibroblast|APCDD1+ fibroblast|CD9+APCDD1+ fibroblast,Fibroblast
+Fibroblast|CFD+MGP+ fibroblast|APOE+ fibroblast|CCL19+APOE+ fibroblast,Fibroblast
+Fibroblast|CFD+MGP+ fibroblast|COCH+ fibroblast|COCH+TNN+ fibroblast,Fibroblast
+Fibroblast|CFD+MGP+ fibroblast|FGFBP2+ fibroblast|FGFBP2+OLFML2A+ fibroblast,Fibroblast
+Fibroblast|Fetal KCNQ1OT1+MIR503HG+ fibroblast,Fibroblast
+Fibroblast|MDK+NREP+ fibroblast|GPC3+ fibroblast|Cycling GPC3+ fibroblast|G2/M phase GPC3+ fibroblast,Fibroblast
+Fibroblast|MDK+NREP+ fibroblast|GPC3+ fibroblast|Cycling GPC3+ fibroblast|S phase GPC3+ fibroblast,Fibroblast
+Fibroblast|MDK+NREP+ fibroblast|ADAMDEC1+ fibroblast|ADAMDEC1+ADAM28+ fibroblast,Fibroblast
+Fibroblast|Mesenchymal stromal cell,Fibroblast
+Fibroblast|Myofibroblast,Fibroblast
+Fibroblast|Metallothionein+ fibroblast|Metallothionein+ Collagen- fibroblast,Fibroblast
+Fibroblast|PCOLCE2 fibroblast,Fibroblast
+Fibroblast|POSTN fibroblast,Fibroblast
+Fibroblast|SCN7A fibroblast,Fibroblast
+Fibroblast|TNC fibroblast,Fibroblast
+Fibroblast|NR4A3 fibroblast,Fibroblast
+Fibroblast|IGFBP6+APOD+ fibroblast,Fibroblast
+Fibroblast|FBLN2+APOD+ fibroblast,Fibroblast
+Fibroblast|IGFBP6+SFRP4+ fibroblast,Fibroblast
+Fibroblast|CXCL+ fibroblast|CXCL8+ fibroblast|APOD+PTGDS+ fibroblast|Collagen+APOD+PTGDS+ fibroblast,Fibroblast
+Fibroblast|CXCL+ fibroblast|CXCL8+ fibroblast|APOD+PTGDS+ fibroblast|IL1RL1+APOD+PTGDS+ fibroblast,Fibroblast
+Fibroblast|CXCL+ fibroblast|CXCL8+ fibroblast|CXCL5+ADAM12+ fibroblast|Cycling CXCL5+ADAM12+ fibroblast|G2/M phase CXCL5+ADAM12+ fibroblast,Fibroblast
+Fibroblast|CXCL+ fibroblast|CXCL8+ fibroblast|CXCL5+ADAM12+ fibroblast|Cycling CXCL5+ADAM12+ fibroblast|S phase CXCL5+ADAM12+ fibroblast,Fibroblast
+Fibroblast|CXCL+ fibroblast|CXCL1/2/3 fibroblast,Fibroblast
+Fibroblast|CCL11+ fibroblast,Fibroblast
+Fibroblast|F3+ fibroblast,Fibroblast
+Fibroblast|Cycling fibroblast,Fibroblast
+Fibroblast|MMP1+ fibroblast,Fibroblast
+Fibroblast|KCNN3+ fibroblast,Fibroblast
+Fibroblast|C3+ fibroblast,Fibroblast
+Fibroblast|CDCA7+ fibroblast|Cycling CDCA7+ fibroblast,Fibroblast
+Fibroblast|GREB1+ fibroblast,Fibroblast
+Fibroblast|PLAC9+ fibroblast,Fibroblast
+Fibroblast|RNASE1+ fibroblast,Fibroblast
+Fibroblast|IGFBP1+ fibroblast,Fibroblast
+Fibroblast|SPARCL1+ fibroblast,Fibroblast
+Fibroblast|ANGPTL7+NRP2+ fibroblast,Fibroblast
+Fibroblast|CCL2+SFRP2+ fibroblast,Fibroblast
+Fibroblast|CD55+SEMA3C+ fibroblast,Fibroblast
+Fibroblast|CLU+ fibroblast,Fibroblast
+Fibroblast|THY1+ fibroblast,Fibroblast
+Fibroblast|C2orf40+ fibroblast,Fibroblast
+Fibroblast|WISP2+ fibroblast,Fibroblast
+Fibroblast|TCIM+NRG1+ fibroblast,Fibroblast
+Fibroblast|FRZB+ fibroblast,Fibroblast
+Fibroblast|G0S2+PPP1R14A+ fibroblast,Fibroblast
+Fibroblast|PLA2G2A+IGFBP4+APOC1+ fibroblast,Fibroblast
+Fibroblast|Adipose ITLN1 fibroblast,Fibroblast
+Germ cell|Oocyte|Meiotic oocyte,Germ cell
+Germ cell|Oocyte|Mitotic oocyte,Germ cell
+Germ cell|Oocyte|Retinoid acid responsive oocyte,Germ cell
+Germ cell|Primordial germ cell|Cycling primordial germ cell,Germ cell
+Germ cell|Spermatocyte|Early spermatocyte,Germ cell
+Germ cell|Spermatocyte|Late spermatocyte,Germ cell
+Germ cell|Spermatocyte|Spermatid|Elongated spermatid,Germ cell
+Germ cell|Spermatocyte|Spermatid|Elongating spermatid,Germ cell
+Germ cell|Spermatocyte|Spermatid|Round spermatid,Germ cell
+Germ cell|Spermatocyte|Spermatogonial stem cell|Cycling spermatogonial stem cell,Germ cell
+Glial cell|Glial cell of brain|Astrocyte|Fibrous astrocyte,Glial cell
+Glial cell|Glial cell of brain|Astrocyte|Protoplasmic astrocyte,Glial cell
+Glial cell|Glial cell of brain|Oligodendrocyte|Oligodendrocyte progenitor cell,Glial cell
+Glial cell|Glial cell of intestine|APOE+BCAN+ glial cell,Glial cell
+Glial cell|Glial cell of intestine|CRYAB+PLAT+ glial cell,Glial cell
+Glial cell|Glial cell of intestine|Cycling glial cell|G2/M phase glial cell,Glial cell
+Glial cell|Glial cell of intestine|Cycling glial cell|S phase glial cell,Glial cell
+Glial cell|Glial cell of intestine|Glia progenitor,Glial cell
+Glial cell|Glial cell of intestine|MBP+MAL+AATK+ glial cell,Glial cell
+Glial cell|Muller glia,Glial cell
+Glial cell|Schwann cell,Glial cell
+Immune cell|Erythrocyte/Megakaryocyte|Megakaryocyte|Platelet,Immune cell
+Immune cell|Erythrocyte/Megakaryocyte|Red blood cell|Erythroblast|Early SOX4+ erythroblast,Immune cell
+Immune cell|Erythrocyte/Megakaryocyte|Red blood cell|Erythroblast|Intermediate EPCAM+ erythroblast,Immune cell
+Immune cell|Erythrocyte/Megakaryocyte|Red blood cell|Erythroblast|Late hemoglobin+ erythroblast|Cycling late hemoglobin+ erythroblast,Immune cell
+Immune cell|Erythrocyte/Megakaryocyte|Red blood cell|Fetal HBG+ erythrocyte,Immune cell
+Immune cell|Lymphoid cell|B cell|B cell precursor|PreB cell|Cycling preB cell,Immune cell
+Immune cell|Lymphoid cell|B cell|B cell precursor|ProB cell|Cycling proB cell,Immune cell
+Immune cell|Lymphoid cell|B cell|Germinal center B cell|Committed GC B cell,Immune cell
+Immune cell|Lymphoid cell|B cell|Germinal center B cell|Cycling GC B cell,Immune cell
+Immune cell|Lymphoid cell|B cell|Germinal center B cell|Dark zone GC B cell|Cycling DZ GC B cell|S phase DZ GC B cell|Histone high S phase DZ GC B cell,Immune cell
+Immune cell|Lymphoid cell|B cell|Germinal center B cell|DZ/LZ B cell,Immune cell
+Immune cell|Lymphoid cell|B cell|Germinal center B cell|Light zone GC B cell,Immune cell
+Immune cell|Lymphoid cell|B cell|Germinal center B cell|Non-cycling GC B cell,Immune cell
+Immune cell|Lymphoid cell|B cell|Germinal center B cell|Pre-GC B cell,Immune cell
+Immune cell|Lymphoid cell|B cell|Memory B cell|Class-switched memory B cell,Immune cell
+Immune cell|Lymphoid cell|B cell|Memory B cell|FCRL4 memory B cell,Immune cell
+Immune cell|Lymphoid cell|B cell|Memory B cell|Unswitched memory B cell,Immune cell
+Immune cell|Lymphoid cell|B cell|MTRNR2L1 B cell,Immune cell
+Immune cell|Lymphoid cell|B cell|Naive B cell|INF-activated naive B cell,Immune cell
+Immune cell|Lymphoid cell|B cell|Plasma cell|Plasma cell precursor,Immune cell
+Immune cell|Lymphoid cell|B cell|Cycling B,Immune cell
+Immune cell|Lymphoid cell|T/NK cell|Cycling T/NK cell|Cycling T cell,Immune cell
+Immune cell|Lymphoid cell|T/NK cell|ILC|SLAMF1+XCL- ILC,Immune cell
+Immune cell|Lymphoid cell|T/NK cell|ILC|SLAMF1-XCL+ ILC,Immune cell
+Immune cell|Lymphoid cell|T/NK cell|NK cell|CD16 NK cell,Immune cell
+Immune cell|Lymphoid cell|T/NK cell|NK cell|CD56 NK cell|INF-activated CD56 NK cell,Immune cell
+Immune cell|Lymphoid cell|T/NK cell|NK cell|CD56 NK cell|GZMK NK cell,Immune cell
+Immune cell|Lymphoid cell|T/NK cell|NK cell|Tissue-resident NK cell,Immune cell
+Immune cell|Lymphoid cell|T/NK cell|NK cell|XCL1 NK cell,Immune cell
+Immune cell|Lymphoid cell|T/NK cell|T cell|abT (entry) cell,Immune cell
+Immune cell|Lymphoid cell|T/NK cell|T cell|Agonist T cell,Immune cell
+Immune cell|Lymphoid cell|T/NK cell|T cell|CD4 T cell|Memory CD4 T cell,Immune cell
+Immune cell|Lymphoid cell|T/NK cell|T cell|CD4 T cell|Naive CD4 T cell,Immune cell
+Immune cell|Lymphoid cell|T/NK cell|T cell|CD4 T cell|Tfh cell,Immune cell
+Immune cell|Lymphoid cell|T/NK cell|T cell|CD4 T cell|Treg cell|Differentiating Treg cell,Immune cell
+Immune cell|Lymphoid cell|T/NK cell|T cell|CD4 T cell|KLRB1 cytotoxic CD4 T,Immune cell
+Immune cell|Lymphoid cell|T/NK cell|T cell|CD4 T cell|GZMK cytotoxic CD4 T cell,Immune cell
+Immune cell|Lymphoid cell|T/NK cell|T cell|CD8 T cell|CD8aa+ T cell,Immune cell
+Immune cell|Lymphoid cell|T/NK cell|T cell|CD8 T cell|INF-activated CD8 T cell,Immune cell
+Immune cell|Lymphoid cell|T/NK cell|T cell|CD8 T cell|Memory CD8 T cell|CXCL13 exhausted CD8 T cell|Cycling CXCL13 exhausted CD8 T cell,Immune cell
+Immune cell|Lymphoid cell|T/NK cell|T cell|CD8 T cell|Memory CD8 T cell|GZMB CD8 T cell,Immune cell
+Immune cell|Lymphoid cell|T/NK cell|T cell|CD8 T cell|Memory CD8 T cell|GZMK CD8 T cell|GZMK+IL7R- CD8 T cell,Immune cell
+Immune cell|Lymphoid cell|T/NK cell|T cell|CD8 T cell|Memory CD8 T cell|GZMK CD8 T cell|GZMK+IL7R+ CD8 T cell,Immune cell
+Immune cell|Lymphoid cell|T/NK cell|T cell|CD8 T cell|Memory CD8 T cell|KLRB1 CD8 T cell,Immune cell
+Immune cell|Lymphoid cell|T/NK cell|T cell|CD8 T cell|Naive CD8 T cell,Immune cell
+Immune cell|Lymphoid cell|T/NK cell|T cell|Cycling DN/DP T cell,Immune cell
+Immune cell|Lymphoid cell|T/NK cell|T cell|Double negative T cell|Double negative T cell (entry),Immune cell
+Immune cell|Lymphoid cell|T/NK cell|T cell|Double positive T cell|Cycling DP T cell,Immune cell
+Immune cell|Lymphoid cell|T/NK cell|T cell|INF-activated T cell,Immune cell
+Immune cell|Lymphoid cell|T/NK cell|T cell|MAIT cell,Immune cell
+Immune cell|Lymphoid cell|T/NK cell|T cell|Memory T cell,Immune cell
+Immune cell|Lymphoid cell|T/NK cell|T cell|Naive T cell,Immune cell
+Immune cell|Myeloid cell|Cycling myeloid cell|G2/M phase myeloid cell,Immune cell
+Immune cell|Myeloid cell|Cycling myeloid cell|S phase myeloid cell,Immune cell
+Immune cell|Myeloid cell|Dendritic cell|Follicular DC|Dark zone follicular DC,Immune cell
+Immune cell|Myeloid cell|Dendritic cell|Follicular DC|Light zone follicular DC,Immune cell
+Immune cell|Myeloid cell|Dendritic cell|mregDC,Immune cell
+Immune cell|Myeloid cell|Granulocyte|Basophil,Immune cell
+Immune cell|Myeloid cell|Granulocyte|Eosinophil,Immune cell
+Immune cell|Myeloid cell|Granulocyte|Mast cell|Cycling mast cell,Immune cell
+Immune cell|Myeloid cell|Granulocyte|Neutrophil|Neutrophil precursor|S100A+ preNeutrophil|Cycling S100A+ preNeutrophil,Immune cell
+Immune cell|Myeloid cell|Macrophage|Cycling macrophage,Immune cell
+Immune cell|Myeloid cell|Macrophage|IL1B+ macrophage,Immune cell
+Immune cell|Myeloid cell|Macrophage|INF-activated macrophage,Immune cell
+Immune cell|Myeloid cell|Macrophage|LYVE1 macrophage|Cycling LYVE1 macrophage,Immune cell
+Immune cell|Myeloid cell|Macrophage|M1 macrophage,Immune cell
+Immune cell|Myeloid cell|Macrophage|Metallothionein+ macrophage,Immune cell
+Immune cell|Myeloid cell|Macrophage|MMP19 macrophage,Immune cell
+Immune cell|Myeloid cell|Macrophage|SPP1 macrophage,Immune cell
+Immune cell|Myeloid cell|Macrophage|Tissue resident macrophage|Alveolar macrophage,Immune cell
+Immune cell|Myeloid cell|Macrophage|Tissue resident macrophage|Hofbauer cell,Immune cell
+Immune cell|Myeloid cell|Macrophage|Tissue resident macrophage|Microglia,Immune cell
+Immune cell|Myeloid cell|Macrophage|DIAPH3+ macrophage,Immune cell
+Immune cell|Myeloid cell|Monocyte|CD14 monocyte|MHCII high CD14 monocyte,Immune cell
+Immune cell|Myeloid cell|Monocyte|CD14 monocyte|MHCII low CD14 monocyte,Immune cell
+Immune cell|Myeloid cell|Monocyte|CD16 monocyte,Immune cell
+Immune cell|Myeloid cell|Monocyte|Cycling monocyte,Immune cell
+Immune cell|Myeloid cell|Monocyte|Placenta CAMP+ monocyte,Immune cell
+Immune cell|Myeloid cell|Monocyte|Placenta defensin+ monocyte,Immune cell
+Immune cell|Myeloid cell|Osteoclast,Immune cell
+Immune cell|Myeloid cell|Monocyte/DC,Immune cell
+Immune cell|Cycling immune cell,Immune cell
+Muscle cell|Cardiomyocyte|Atrial cardiomyocyte,Muscle cell
+Muscle cell|Cardiomyocyte|Ventricular cardiomyocyte|Fetal ventricular cardiomyocyte,Muscle cell
+Muscle cell|Skeletal muscle cell|Fast-twitch skeletal muscle cell,Muscle cell
+Muscle cell|Skeletal muscle cell|MYOM1+ skeletal muscle cell,Muscle cell
+Muscle cell|Skeletal muscle cell|Skeletal muscle myoblast,Muscle cell
+Muscle cell|Skeletal muscle cell|Slow-twitch skeletal muscle cell,Muscle cell
+Neuron|Neuron of brain|Excitatory neuron|Amygdala excitatory neuron,Neuron
+Neuron|Neuron of brain|Excitatory neuron|Thalamic excitatory neuron,Neuron
+Neuron|Neuron of brain|Excitatory neuron|Hippocampal excitatory neurons|Hippocampal CA1-3 neuron,Neuron
+Neuron|Neuron of brain|Excitatory neuron|Hippocampal excitatory neurons|Hippocampal dentate gyrus neuron,Neuron
+Neuron|Neuron of brain|Excitatory neuron|Hippocampal excitatory neurons|Hippocampal CA4 neuron,Neuron
+Neuron|Neuron of brain|Inhibitory neuron|MGE-derived inhibitory neuron|SST inhibitory neuron,Neuron
+Neuron|Neuron of brain|Inhibitory neuron|CGE-derived inhibitory neuron|SV2C inhibitory neuron,Neuron
+Neuron|Neuron of brain|Inhibitory neuron|CGE-derived inhibitory neuron|VIP inhibitory neuron,Neuron
+Neuron|Neuron of brain|Inhibitory neuron|Cerebellar inhibitory neuron|PAX2 inhibitory neuron,Neuron
+Neuron|Neuron of brain|Inhibitory neuron|Cerebellar inhibitory neuron|SCGN inhibitory neuron,Neuron
+Neuron|Neuron of brain|Inhibitory neuron|Midbrain-derived inhibitory neuron,Neuron
+Neuron|Neuron of brain|Inhibitory neuron|Medium spiny neurons|D1 medium spiny neuron,Neuron
+Neuron|Neuron of brain|Inhibitory neuron|Medium spiny neurons|D2 medium spiny neuron,Neuron
+Neuron|Neuron of brain|Inhibitory neuron|Medium spiny neurons|Eccentric medium spiny neuron,Neuron
+Neuron|Neuron of brain|Miscellaneous neuron|Upper rhombic lip-derived neuron,Neuron
+Neuron|Neuron of brain|Miscellaneous neuron|Lower rhombic lip-derived neuron,Neuron
+Neuron|Neuron of brain|Miscellaneous neuron|Splatter neuron,Neuron
+Neuron|Neuron of brain|Miscellaneous neuron|Mammillary body neuron,Neuron
+Neuron|Neuron of intestine|BNC2+ neuron,Neuron
+Neuron|Neuron of intestine|ETV1+ neuron,Neuron
+Neuron|Neuron of intestine|Neuroblast,Neuron
+Neuron|Neuron of retina|Amacrine cell,Neuron
+Neuron|Neuron of retina|Bipolar cell|Cone-OFF-bipolar cell,Neuron
+Neuron|Neuron of retina|Bipolar cell|Cone-ON-bipolar cell,Neuron
+Neuron|Neuron of retina|Bipolar cell|PCP4L1+ bipolar cell,Neuron
+Neuron|Neuron of retina|Bipolar cell|Rod-bipolar cell,Neuron
+Neuron|Neuron of retina|Cone cell,Neuron
+Neuron|Neuron of retina|Ganglion cell,Neuron
+Neuron|Neuron of retina|Horizontal cell,Neuron
+Neuron|Neuron of retina|Rod cell,Neuron
+Perivascular cell|Cycling perivascular cell,Perivascular cell
+Perivascular cell|Pericyte|ACTG2+ contractile pericyte|Cycling ACTG2+ contractile pericyte,Perivascular cell
+Perivascular cell|Pericyte|CCL19/21 pericyte,Perivascular cell
+Perivascular cell|Pericyte|CXCL+ pericyte,Perivascular cell
+Perivascular cell|Pericyte|CYGB+ pericyte,Perivascular cell
+Perivascular cell|Pericyte|SPRR2F+ pericyte,Perivascular cell
+Perivascular cell|Pericyte|Mesangial cell,Perivascular cell
+Perivascular cell|Vascular smooth muscle cell|ACTG2+ contractile VSMC,Perivascular cell
+Perivascular cell|Vascular smooth muscle cell|CREB+MT1A+ vascular smooth muscle cell,Perivascular cell
+Perivascular cell|Vascular smooth muscle cell|PCP4+ vascular smooth muscle cell,Perivascular cell
+Perivascular cell|Vascular smooth muscle cell|Metallothionein+ smooth muscle cell,Perivascular cell
+Immune cell|Hematopoietic precursor cell|CLP,Immune cell
+Immune cell|Hematopoietic precursor cell|HSC,Immune cell
+Immune cell|Hematopoietic precursor cell|MEP,Immune cell
+Epithelial cell|Epithelial cell of kidney|Renal epithelial cell - distal tubules,Epithelial cell
+Epithelial cell|Epithelial cell of kidney|Renal epithelial cell - Loop of Henle,Epithelial cell
+Epithelial cell|Epithelial cell of kidney|Renal epithelial cell - proximal tubules,Epithelial cell
+Neuron|Neuron of brain|Inhibitory neuron|PVALB inhibitory neuron,Neuron
+Neuron|Neuron of brain|Inhibitory neuron|CXCL14 inhibitory neuron,Neuron
+Immune cell|Lymphoid cell|T/NK cell|T cell|gdT cell,Immune cell
+Immune cell|Myeloid cell|Dendritic cell|cDC|cDC1,Immune cell
+Immune cell|Myeloid cell|Dendritic cell|cDC|cDC2,Immune cell
+Immune cell|Myeloid cell|Dendritic cell|pDC,Immune cell
+Immune cell|Myeloid cell|Monocyte|CD14orCD16 monocyte,Immune cell
+Endothelial cell|Tip EC,Endothelial cell
+Immune cell|Hematopoietic precursor cell|EoBaMa Progenitor,Immune cell
+Immune cell|Hematopoietic precursor cell|GMP|Early GMP,Immune cell
+Immune cell|Hematopoietic precursor cell|GMP|Late GMP,Immune cell
+Immune cell|Hematopoietic precursor cell|LMPP,Immune cell
+Immune cell|Hematopoietic precursor cell|MkP,Immune cell
+Immune cell|Hematopoietic precursor cell|MPP|MPP-Cycling,Immune cell
+Immune cell|Hematopoietic precursor cell|MPP|MPP-MkEry,Immune cell
+Immune cell|Hematopoietic precursor cell|MPP|MPP-MyLy,Immune cell
+Immune cell|Hematopoietic precursor cell|Pre-cDC,Immune cell
+Immune cell|Hematopoietic precursor cell|Pre-pDC,Immune cell
+Immune cell|Lymphoid cell|B cell|B cell precursor|Pre-ProB cell,Immune cell
+Immune cell|Lymphoid cell|B cell|Memory B cell|Memory B cell precursor,Immune cell
+Immune cell|Myeloid cell|Dendritic cell|ASDC,Immune cell
+Neuron|Neuron of brain|Excitatory neuron|Cortical excitatory neuron|Deep-layer excitatory neuron|L4 excitatory neuron,Neuron
+Neuron|Neuron of brain|Excitatory neuron|Cortical excitatory neuron|Deep-layer excitatory neuron|L5 excitatory neuron,Neuron
+Neuron|Neuron of brain|Excitatory neuron|Cortical excitatory neuron|Deep-layer excitatory neuron|L5/6 excitatory neuron,Neuron
+Neuron|Neuron of brain|Excitatory neuron|Cortical excitatory neuron|Deep-layer excitatory neuron|L5b excitatory neuron,Neuron
+Neuron|Neuron of brain|Excitatory neuron|Cortical excitatory neuron|Deep-layer excitatory neuron|L6 excitatory neuron,Neuron
+Neuron|Neuron of brain|Excitatory neuron|Cortical excitatory neuron|Deep-layer excitatory neuron|TSHZ2 L4/5 excitatory neuron,Neuron
+Neuron|Neuron of brain|Excitatory neuron|Cortical excitatory neuron|Upper-layer excitatory neuron|L2/3 excitatory neuron,Neuron
+Neuron|Neuron of brain|Excitatory neuron|PLCH1 L4/5 excitatory neuron,Neuron
+Neuron|Neuron of brain|Excitatory neuron|Pyramidal neuron,Neuron


### PR DESCRIPTION
## Description
Checklist of guidelines to go through when making a PR.

## Type of Change
- [x] Bug fix (patch version)
- [ ] New or updated feature (minor version)  
- [ ] New default model (major version + new constellation for version name)
- [ ] Documentation update
- [ ] Internal refactoring

**Does this PR introduce a breaking change to the *public API* of existing features/models?**
- [ ] Yes (If yes, this *will* require a Major version bump. Explain in "Additional Notes")
- [x] No

## Pre-Merge Checklist
**Please check each item before requesting review:**

### Code Quality
- [x] Tests pass locally: `python -m pytest tests/`
- [ ] New functionality has tests written
- [ ] No debugging code left behind (print statements, breakpoints)
- [ ] Package installs cleanly: `pip install -e .`

### Documentation
- [ ] README.md updated for user-facing changes and model version updates if necessary
- [ ] Docstrings added for new functions
- [ ] Tutorial notebook updated if needed

### Model Changes (if applicable)
- [ ] New models tested with sample data
- [ ] Model files added to appropriate `_tools/` subdirectory
- [ ] Backward compatibility maintained (old models still work)

### Git Hygiene
- [x] Branch is up to date with main
- [x] No `__pycache__` files committed
- [x] Commit messages are descriptive
- [x] No merge conflicts

## Version Impact (Maintainer Decision)
- [x] No version change needed
- [ ] Should trigger version bump:
  - [ ] Patch (bug fix)
  - [ ] Minor (new or updated feature)  
  - [ ] Major (breaking change to existing API, **or a new default model** which is a "soft" breaking change) - change constellation for version name

## Testing
Existing tests passed

## Additional Notes
Previously, refinement at broad was mapping directly to level 0 and bypassing the csv files completely, which was fine for v0 as there was none. To make it coherent across version, I added a broad csv for v0 which is essentially an identity map at level 0 (not the case in v1), and implemented the same logic for broad refinement as for medium and fine independent of version. Results for v0 unchanged. 
