### PR TITLE
Added addtional handling of medium and fine refinement for emtpy calls.

### DIFF
--- a/src/panhumanpy/ANNotate.py
+++ b/src/panhumanpy/ANNotate.py
@@ -598,6 +598,20 @@ class AzimuthNN_base(AutoloadInferenceTools):
             'softmax_vals_all'
         ]
 
+        # this conditional block is to specifically handle refinement
+        # of empty cell calls at medium and fine levels.
+        if refine_level in ['medium', 'fine']:
+            labels_pred = np.array(labels_pred, dtype=object).copy()
+            prev_labels = self._azimuth_refined_labels.get(
+                'azimuth_broad', None
+                )
+            if prev_labels is not None:
+                for i, label in enumerate(labels_pred):
+                    labels_pred[i] = [
+                        prev_labels[i] + l[len('Empty'):] 
+                        if l.startswith('Empty') else l for l in label
+                        ]
+
         refine_class = PostprocessingAzimuthLabels(
             labels_pred,
             labels_prob,


### PR DESCRIPTION
## Description
Checklist of guidelines to go through when making a PR.

## Type of Change
- [x] Bug fix (patch version)
- [ ] New or updated feature (minor version)  
- [ ] New default model (major version + new constellation for version name)
- [ ] Documentation update
- [ ] Internal refactoring

**Does this PR introduce a breaking change to the *public API* of existing features/models?**
- [ ] Yes (If yes, this *will* require a Major version bump. Explain in "Additional Notes")
- [x] No

## Pre-Merge Checklist
**Please check each item before requesting review:**

### Code Quality
- [x] Tests pass locally: `python -m pytest tests/`
- [ ] New functionality has tests written
- [ ] No debugging code left behind (print statements, breakpoints)
- [ ] Package installs cleanly: `pip install -e .`

### Documentation
- [ ] README.md updated for user-facing changes and model version updates if necessary
- [ ] Docstrings added for new functions
- [ ] Tutorial notebook updated if needed

### Model Changes (if applicable)
- [ ] New models tested with sample data
- [ ] Model files added to appropriate `_tools/` subdirectory
- [ ] Backward compatibility maintained (old models still work)

### Git Hygiene
- [x] Branch is up to date with main
- [x] No `__pycache__` files committed
- [x] Commit messages are descriptive
- [x] No merge conflicts

## Version Impact (Maintainer Decision)
- [x] No version change needed
- [ ] Should trigger version bump:
  - [ ] Patch (bug fix)
  - [ ] Minor (new or updated feature)  
  - [ ] Major (breaking change to existing API, **or a new default model** which is a "soft" breaking change) - change constellation for version name

## Testing
Exisiting tests are sufficient. 

## Additional Notes
From Skylar:
In ANNotate.py:
- Improved the logic in the refine_labels method to handle cases where a cell's predicted labels are all variants of "Empty" (e.g., 'Empty', 'Empty|', etc.). This means only consistent labels are handled properly (not Empty|Lymphoid cell| etc.)
- For such cells, each 'Empty' entry in the hierarchy is now replaced with the corresponding label from the previous azimuth_broad refinement, preserving the correct number of trailing pipes (e.g., 'Empty||' becomes 'Immune cell||').
- This ensures that "Empty" cells are refined at the medium and fine levels based on the best available label from the broad level

Additionally, on the broad csv (a previous PR):
panhuman_annotate_broad.csv
- Added file so that refinement happens using refinement logic, and not taking level_zero_label
- Added "Empty|" entries so that "Empty" would not receive an exact match, but a partial match to a key where there are 12 potential items



