### PR TITLE
Patch/confidence column name

### DIFF
--- a/src/panhumanpy/ANNotate.py
+++ b/src/panhumanpy/ANNotate.py
@@ -634,8 +634,8 @@ class AzimuthNN_base(AutoloadInferenceTools):
         combined_labels = output_processing_class.combined_labels
         level_zero_labels = output_processing_class.level_zero_labels
         final_level_labels = output_processing_class.final_level_labels
-        final_level_softmax_prob = (
-            output_processing_class.final_level_softmax_prob
+        final_level_prob = (
+            output_processing_class.final_level_prob
         )
         full_consistent_hierarchy = (
             output_processing_class.full_consistent_hierarchy
@@ -645,7 +645,7 @@ class AzimuthNN_base(AutoloadInferenceTools):
             'full_hierarchical_labels': combined_labels,
             'level_zero_labels': level_zero_labels,
             'final_level_labels': final_level_labels,
-            'final_level_softmax_prob': final_level_softmax_prob,
+            'final_level_confidence': final_level_prob,
             'full_consistent_hierarchy': full_consistent_hierarchy
         }
 
@@ -706,7 +706,7 @@ class AzimuthNN_base(AutoloadInferenceTools):
         labels_prob = self._inference_outputs_unprocessed[
             'probability_of_preds'
         ]
-        softmax_probs = self._inference_outputs_unprocessed[
+        probs = self._inference_outputs_unprocessed[
             'softmax_vals_all'
         ]
 
@@ -729,7 +729,7 @@ class AzimuthNN_base(AutoloadInferenceTools):
             labels_prob,
             self.max_depth,
             self.num_cells,
-            softmax_probs,
+            probs,
             self.inference_encoders,
             refine_level,
             self._model_version

--- a/src/panhumanpy/ANNotate_tools.py
+++ b/src/panhumanpy/ANNotate_tools.py
@@ -2449,6 +2449,7 @@ class OutputLabels():
         (num_cells, max_depth).
     labels_prob : numpy.ndarray
         Probability scores associated with each prediction.
+        These scores could be pre or post-calibration.
     max_depth : int
         Maximum depth of the hierarchical classification.
     num_cells : int
@@ -2462,10 +2463,14 @@ class OutputLabels():
         Labels at the top level (level 0) of the hierarchy.
     final_level_labels : numpy.ndarray
         Labels at the final level determined for each cell.
-    level_zero_softmax_prob : numpy.ndarray
-        Softmax probabilities for the top level predictions.
-    final_level_softmax_prob : numpy.ndarray
-        Softmax probabilities for the final level predictions.
+    level_zero_prob : numpy.ndarray
+        Probabilities for the top level predictions.
+        Could be calibrated confidence scores or uncalibrated softmax
+        values (depending on the specific pipeline implemented).
+    final_level_prob : numpy.ndarray
+        Probabilities for the final level predictions.
+        Could be calibrated confidence scores or uncalibrated softmax
+        values (depending on the specific pipeline implemented).
     full_consistent_hierarchy : list
         Flags indicating whether each cell has a fully consistent 
         hierarchy.
@@ -2510,8 +2515,8 @@ class OutputLabels():
             self._max_depth+1
         ]
 
-        self.level_zero_softmax_prob = self._labels_prob[:,0]
-        self.final_level_softmax_prob = self._labels_prob[
+        self.level_zero_prob = self._labels_prob[:,0]
+        self.final_level_prob = self._labels_prob[
             np.arange(self._num_cells), 
             self._final_levels_array
             ]
@@ -2524,9 +2529,11 @@ class OutputLabels():
         self.full_consistent_hierarchy = full_consistent_hierarchy
 
        
-    def level_specific_softmax_prob(self, level):
+    def level_specific_prob(self, level):
         """
-        Get softmax probabilities for a specific hierarchical level.
+        Get probabilities for a specific hierarchical level.
+        These could be calibrated confidence scores or raw softmax values,
+        depending on the specific pipeline that has been implemented.
         
         Parameters
         ----------
@@ -2536,7 +2543,7 @@ class OutputLabels():
         Returns
         -------
         numpy.ndarray
-            Softmax probabilities for the specified level.
+            Probabilities for the specified level.
             
         Raises
         ------
@@ -2550,8 +2557,8 @@ class OutputLabels():
         if level < 1 or level > self._max_depth:
             raise ValueError(f"level must be between 1 and {self._max_depth}")
         
-        softmax_probs = self._labels_prob[:,level-1]
-        return softmax_probs
+        probs = self._labels_prob[:,level-1]
+        return probs
         
 
     def level_specific_labels(self, level):
@@ -2621,8 +2628,10 @@ class PostprocessingAzimuthLabels(OutputLabels):
         Maximum depth of the hierarchical classification.
     num_cells : int
         Number of cells/samples in the query data.
-    softmax_probs : list of numpy.ndarray
-        Softmax probability arrays for each level of the hierarchy.
+    probs : list of numpy.ndarray
+        Probability arrays for each level of the hierarchy.
+        These values could be calibrated confidence scores or 
+        uncalibrated softmax values depending on the pipeline implemented.
     encoders : list
         List of label encoders used during model training/inference.
     refine_level : str
@@ -2632,8 +2641,11 @@ class PostprocessingAzimuthLabels(OutputLabels):
         
     Attributes
     ----------
-    softmax_probs : list of numpy.ndarray
-        Softmax probability arrays for each level.
+    probs : list of numpy.ndarray
+        Probability arrays for each level.
+        These values could be calibrated confidence scores, or 
+        uncalibrated softmax values depending on the pipeline that has 
+        been implemented.
     refine_level : str
         Selected level of refinement.
     encoders : list
@@ -2668,7 +2680,7 @@ class PostprocessingAzimuthLabels(OutputLabels):
         labels_prob, 
         max_depth, 
         num_cells,
-        softmax_probs,
+        probs,
         encoders,
         refine_level,
         model_version
@@ -2686,7 +2698,7 @@ class PostprocessingAzimuthLabels(OutputLabels):
             num_cells
             )
 
-        self.softmax_probs = softmax_probs
+        self.probs = probs
         self.refine_level = refine_level
         self.encoders = encoders
 
@@ -2797,7 +2809,7 @@ class PostprocessingAzimuthLabels(OutputLabels):
 
         softmax = {
             f"arr_{i}": np.array(row) for i, row 
-            in enumerate(self.softmax_probs)
+            in enumerate(self.probs)
             }
 
         return softmax

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -211,7 +211,7 @@ def test_azimuthnn_base_with_h5ad():
             'full_hierarchical_labels',
             'level_zero_labels',
             'final_level_labels',
-            'final_level_softmax_prob',
+            'final_level_confidence',
             'full_consistent_hierarchy'
         ]
 
@@ -624,7 +624,7 @@ def test_azimuthnn_base_with_h5ad_alternate_models(model_version):
             'full_hierarchical_labels',
             'level_zero_labels',
             'final_level_labels',
-            'final_level_softmax_prob',
+            'final_level_confidence',
             'full_consistent_hierarchy'
         ]
 


### PR DESCRIPTION
## Description
Checklist of guidelines to go through when making a PR.

## Type of Change
- [x] Bug fix (patch version)
- [ ] New or updated feature (minor version)  
- [ ] New default model (major version + new constellation for version name)
- [ ] Documentation update
- [ ] Internal refactoring

**Does this PR introduce a breaking change to the *public API* of existing features/models?**
- [ ] Yes (If yes, this *will* require a Major version bump. Explain in "Additional Notes")
- [x] No

## Pre-Merge Checklist
**Please check each item before requesting review:**

### Code Quality
- [x] Tests pass locally: `python -m pytest tests/`
- [ ] New functionality has tests written
- [x] No debugging code left behind (print statements, breakpoints)
- [x] Package installs cleanly: `pip install -e .`

### Documentation
- [ ] README.md updated for user-facing changes and model version updates if necessary
- [ ] Docstrings added for new functions
- [ ] Tutorial notebook updated if needed

### Model Changes (if applicable)
- [ ] New models tested with sample data
- [ ] Model files added to appropriate `_tools/` subdirectory
- [ ] Backward compatibility maintained (old models still work)

### Git Hygiene
- [ ] Branch is up to date with main
- [ ] No `__pycache__` files committed
- [ ] Commit messages are descriptive
- [ ] No merge conflicts

## Version Impact (Maintainer Decision)
- [x] No version change needed
- [ ] Should trigger version bump:
  - [ ] Patch (bug fix)
  - [ ] Minor (new or updated feature)  
  - [ ] Major (breaking change to existing API, **or a new default model** which is a "soft" breaking change) - change constellation for version name

## Testing
Modified existing changes to adapt to the new column names, and tests pass.

## Additional Notes
Changed some variable names from softmax_probs to probs to better reflect that these could be calibrated softmax values if calibration is implemented. Also changed name of metadata column from final_level_softmax_probs to final_level_confidence. This is a superficial change to the API which might necessitate the user to make corresponding adjustments to their pipelines, but the results are not affected for a given model. 

